### PR TITLE
Report returns monthly, not weekly

### DIFF
--- a/CountUsers.groovy
+++ b/CountUsers.groovy
@@ -22,16 +22,16 @@ Map buildSummary(File reportFile, Date from) {
 
     def report = new JsonSlurper().parseText(reportFile.text)
 
-    def authAccess = report.authAccess.findAll { dateFormat.parse(it.firstDayOfWeek).after(from) }
-    def authAccessFrom = authAccess*.firstDayOfWeek.min() ?: dateFormat.format(from)
-    def authAccessTo = authAccess*.firstDayOfWeek.max() ?: dateFormat.format(new Date())
+    def authAccess = report.authAccess.findAll { dateFormat.parse(it.firstDayOfMonth).after(from) }
+    def authAccessFrom = authAccess*.firstDayOfMonth.min() ?: dateFormat.format(from)
+    def authAccessTo = authAccess*.firstDayOfMonth.max() ?: dateFormat.format(new Date())
     def authAccessUsers = authAccess*.name.unique()
 
     println "${authAccessUsers.size()} user(s) counted as Authenticated from ${authAccessFrom} to ${authAccessTo}"
 
-    def scmAccess = report.scmAccess.findAll { dateFormat.parse(it.firstDayOfWeek).after(from) }
-    def scmAccessFrom = scmAccess*.firstDayOfWeek.min() ?: dateFormat.format(from)
-    def scmAccessTo = scmAccess*.firstDayOfWeek.max() ?: dateFormat.format(new Date())
+    def scmAccess = report.scmAccess.findAll { dateFormat.parse(it.firstDayOfMonth).after(from) }
+    def scmAccessFrom = scmAccess*.firstDayOfMonth.min() ?: dateFormat.format(from)
+    def scmAccessTo = scmAccess*.firstDayOfMonth.max() ?: dateFormat.format(new Date())
     def scmAccessUsers = scmAccess*.name.unique()
 
     println "${scmAccessUsers.size()} user(s) counted as SCM contributor from ${scmAccessFrom} to ${scmAccessTo}"

--- a/MergeReports.groovy
+++ b/MergeReports.groovy
@@ -25,16 +25,16 @@ Map buildReport(File reportsFolder) {
 
     rawData.forEach { reportEntry ->
         reportEntry.authAccess.each { stat ->
-            authAccess << ["server": reportEntry.server, "firstDayOfWeek": stat.firstDayOfWeek, "name": stat.name]
+            authAccess << ["server": reportEntry.server, "firstDayOfMonth": stat.firstDayOfMonth, "name": stat.name]
         }
         reportEntry.scmAccess.each { stat ->
-            scmAccess << ["server": reportEntry.server, "firstDayOfWeek": stat.firstDayOfWeek, "name": stat.name]
+            scmAccess << ["server": reportEntry.server, "firstDayOfMonth": stat.firstDayOfMonth, "name": stat.name]
         }
     }
 
     return [
-            "authAccess": authAccess.toSorted(new OrderBy([{ it.firstDayOfWeek }, { it.name }, { it.server.url }])),
-            "scmAccess" : scmAccess.toSorted(new OrderBy([{ it.firstDayOfWeek }, { it.name }, { it.server.url }]))]
+            "authAccess": authAccess.toSorted(new OrderBy([{ it.firstDayOfMonth }, { it.name }, { it.server.url }])),
+            "scmAccess" : scmAccess.toSorted(new OrderBy([{ it.firstDayOfMonth }, { it.name }, { it.server.url }]))]
 }
 
 String getRelativePath(File base, File path) {

--- a/README.md
+++ b/README.md
@@ -13,23 +13,23 @@ Detailed activity reports can be generated across multiple masters using the fol
 * [merge-user-activity-monitoring-reports.sh](./merge-user-activity-monitoring-reports.sh)
     * generates a unique report called `/out/aggregated-user-activity.json`
     * `/out/aggregated-user-activity.json` contains a list of all `authAccess` entries and a list of all `scmAccess` entries
-    * The entries contain the `firstDayOfWeek`, the `name` and the `server` entry like:
+    * The entries contain the `firstDayOfMonth`, the `name` and the `server` entry like:
     ```
     {
         "server": {
             "url": "https://cd.wordsmith.beescloud.com/teams-front-team/",
             "id": "21e47a96ced17c97e72f91cd7f7c6a0f"
         },
-        "firstDayOfWeek": "2018-10-28",
+        "firstDayOfMonth": "2018-10-01",
         "name": "simon"
     }
     ```
 * [count-user-activity.sh](./count-user-activity.sh)
     * displays on the stdout the summary of the users counted from `/out/aggregated-user-activity.json`:
     ```
-    1 user(s) counted as Authenticated from 2018-10-28 to 2019-02-03
-    3 user(s) counted as SCM contributor from 2018-10-28 to 2018-12-30
-    4 user(s) counted as CloudBees Core users from 2018-10-28 to 2019-02-03
+    1 user(s) counted as Authenticated from 2018-10-01 to 2019-02-01
+    3 user(s) counted as SCM contributor from 2018-10-01 to 2018-12-01
+    4 user(s) counted as CloudBees Core users from 2018-10-01 to 2019-02-01
     Detailed summary available in: ./aggregated-user-activity-summary.json
     ```
     * Generates a file `/out/aggregated-user-activity-summary.json` with such content:


### PR DESCRIPTION
We are on user-activity-monitoring-plugin 1.1.5 and the reports seem to have firstDayOfMonth fields, not firstDayOfWeek fields.  Dunno if this behavior changed recently, as we've just installed the plugin.