### PR TITLE
Authentication was not being used in commands

### DIFF
--- a/get-user-activity-monitoring-reports.sh
+++ b/get-user-activity-monitoring-reports.sh
@@ -32,7 +32,7 @@ else
 fi
 
 echo -n "Collecting list of masters..."
-masters=( $(java -jar "${JENKINS_CLI_JAR}" -s "${OPS_CENTER_URL}" list-masters | IFS='\n' jq -cr '.data.masters[] | select(.status == "ONLINE")') )
+masters=( $(java -jar "${JENKINS_CLI_JAR}" -s "${OPS_CENTER_URL}" -auth "${JENKINS_USER_ID}:${JENKINS_API_TOKEN}" list-masters | IFS='\n' jq -cr '.data.masters[] | select(.status == "ONLINE")') )
 echo " done"
 
 mkdir -p "${HERE}/out/reports"
@@ -44,5 +44,5 @@ for master in "${masters[@]}"; do
 	masterName=$(echo "${master}" | jq -r '.fullName')
 	masterUrl=$(echo "${master}" | jq -r '.url')
 	echo -en " * ${masterName}: "
-	java -jar "${JENKINS_CLI_JAR}" -s "${masterUrl}" user-activity-report > "${HERE}/out/reports/USER-ACTIVITY-MONITORING-${masterName/\//_}-$(date '+%Y%m%d-%H%M%S').json" 2> "${HERE}/out/logs/USER-ACTIVITY-MONITORING-${masterName/\//_}-$(date '+%Y%m%d-%H%M%S')-error.log" && echo "done" || echo "ko"
+	java -jar "${JENKINS_CLI_JAR}" -s "${masterUrl}" -auth "${JENKINS_USER_ID}:${JENKINS_API_TOKEN}" user-activity-report > "${HERE}/out/reports/USER-ACTIVITY-MONITORING-${masterName/\//_}-$(date '+%Y%m%d-%H%M%S').json" 2> "${HERE}/out/logs/USER-ACTIVITY-MONITORING-${masterName/\//_}-$(date '+%Y%m%d-%H%M%S')-error.log" && echo "done" || echo "ko"
 done


### PR DESCRIPTION
The instructions state to add JENKINS_USER_ID and JENKINS_API_TOKEN to file which will be sourced. However, these are not used in the jenkins cli to run the user reports. I had to make this change locally for the script to work.