### PR TITLE
[CTR-445] Run user-activity generate report on all Jenkins masters in CJE cluster

### DIFF
--- a/get-user-activity-monitoring-reports.sh
+++ b/get-user-activity-monitoring-reports.sh
@@ -31,8 +31,11 @@ else
 	wget -q -O "${JENKINS_CLI_JAR}" "${OPS_CENTER_URL}/jnlpJars/jenkins-cli.jar"
 fi
 
+# otherwise space is going to be used as line separator
+IFS=$'\n'
+
 echo -n "Collecting list of masters..."
-masters=( $(java -jar "${JENKINS_CLI_JAR}" -s "${OPS_CENTER_URL}" list-masters | IFS='\n' jq -cr '.data.masters[] | select(.status == "ONLINE")') )
+masters=( $(java -jar "${JENKINS_CLI_JAR}" -s "${OPS_CENTER_URL}" list-masters | jq -cr '.data.masters[] | select(.status == "ONLINE")') )
 echo " done"
 
 mkdir -p "${HERE}/out/reports"

--- a/install-user-activity-monitoring-plugin.sh
+++ b/install-user-activity-monitoring-plugin.sh
@@ -33,8 +33,11 @@ fi
 
 mkdir -p "${HERE}/reports/"
 
+# otherwise space is going to be used as line separator
+IFS=$'\n'
+
 echo -n "Collecting list of masters..."
-masters=( $(java -jar "${JENKINS_CLI_JAR}" -s "${OPS_CENTER_URL}" list-masters | IFS='\n' jq -cr '.data.masters[] | select(.status == "ONLINE")') )
+masters=( $(java -jar "${JENKINS_CLI_JAR}" -s "${OPS_CENTER_URL}" list-masters | jq -cr '.data.masters[] | select(.status == "ONLINE")') )
 echo " done"
 
 echo "Install plugin on masters..."


### PR DESCRIPTION
[CTR-445](https://cloudbees.atlassian.net/browse/CTR-445).

## Release Notes

### Issue Type
bug

### Severity
minor

### Description
Problem: Master names containing spaces are not properly generating data. IFS environment variable is not properly located in scripts taking the default value, space, as line separator.
Fix: Set the proper value for IFS environment variable.

# Submitter checklist
- [x] I have read and understood the [Rules of Engagement](https://cloudbees.atlassian.net/wiki/spaces/CORE/pages/938082485/Rules+of+Engagement)
- [x] Change is code complete and matches issue description.
- [x] Commit messages are self contained and descriptive.
- [x] Testing notes provided and reviewed in the JIRA and any manual/developer testing has been performed.
- [x] Code conforms to the style guide.
