### PR TITLE
[SECO-870] export the user/authentication token

### DIFF
--- a/get-user-activity-monitoring-reports.sh
+++ b/get-user-activity-monitoring-reports.sh
@@ -21,6 +21,9 @@ if [[ -z "${JENKINS_API_TOKEN:-""}" ]]; then
     exit 1
 fi
 
+export JENKINS_USER_ID
+export JENKINS_API_TOKEN
+
 # INSTALL JENKINS CLI
 mkdir -p "${HERE}/.jenkins"
 JENKINS_CLI_JAR="${HERE}/.jenkins/jenkins-cli.jar"

--- a/install-user-activity-monitoring-plugin.sh
+++ b/install-user-activity-monitoring-plugin.sh
@@ -21,6 +21,9 @@ if [[ -z "$JENKINS_API_TOKEN" ]]; then
     exit 1
 fi
 
+export JENKINS_USER_ID
+export JENKINS_API_TOKEN
+
 # INSTALL JENKINS CLI
 mkdir -p "${HERE}/.jenkins"
 JENKINS_CLI_JAR="${HERE}/.jenkins/jenkins-cli.jar"


### PR DESCRIPTION
java is a separate process so does not see the script local variables
for authentication.

These are now exported so that the scripts will work icorrectly when authenication
is eanbled.